### PR TITLE
Improve method for representative retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Citing DEIMoS
 -------------
 If you would like to reference deimos in an academic paper, we ask you include the following.
 
-* DEIMoS, version 1.3.0 http://github.com/pnnl/deimos (accessed MMM YYYY)
+* DEIMoS, version 1.3.1 http://github.com/pnnl/deimos (accessed MMM YYYY)
 * Colby, S.M., Chang, C.H., Bade, J.L., Nunez, J.R., Blumer, M.R., Orton, D.J., Bloodsworth, K.J., Nakayasu, E.S., Smith, R.D, Ibrahim, Y.M. and Renslow, R.S., 2022. DEIMoS: an open-source tool for processing high-dimensional mass spectrometry data. *Analytical Chemistry*, 94(16), pp.6130-6138.
 
 Disclaimer

--- a/deimos/__init__.py
+++ b/deimos/__init__.py
@@ -4,4 +4,4 @@ from deimos.io import get_accessions, load, save, build_factors, build_index
 from deimos.subset import (collapse, locate, locate_asym,
                            multi_sample_partition, partition, slice, threshold)
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/deimos/alignment.py
+++ b/deimos/alignment.py
@@ -324,7 +324,7 @@ def agglomerative_clustering(features,
     try:
         clustering = AgglomerativeClustering(n_clusters=None,
                                              linkage='complete',
-                                             affinity='precomputed',
+                                             metric='precomputed',
                                              distance_threshold=1,
                                              connectivity=cmat).fit(distances)
         features['cluster'] = clustering.labels_

--- a/deimos/deconvolution.py
+++ b/deimos/deconvolution.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 from scipy.interpolate import UnivariateSpline
-from scipy.spatial.kdtree import KDTree
+from scipy.spatial import KDTree
 
 import deimos
 

--- a/deimos/deconvolution.py
+++ b/deimos/deconvolution.py
@@ -24,6 +24,7 @@ def cosine(a, b):
 
     a_ = a.flatten()
     b_ = b.flatten()
+
     return 1 - np.dot(a_, b_) / np.sqrt(a_.dot(a_) * b_.dot(b_))
 
 
@@ -340,7 +341,7 @@ class MS2Deconvolution:
         # Enumerate MS1 featres
         for name, grp in self.decon_pairs.groupby(by=['index_ms1'], as_index=False):
             # MS1 feature index
-            idx_i = int(name)
+            idx_i = int(name[0])
 
             # Extracted ion
             ms1_xi = ms1_xis[idx_i]

--- a/deimos/subset.py
+++ b/deimos/subset.py
@@ -561,9 +561,9 @@ class MultiSamplePartitions:
                                                  self.bounds[self.counter][1])
 
             if self.dask:
-                subset = self.features.query(q).compute()
+                subset = self.features.query(q).compute().reset_index(drop=True)
             else:
-                subset = self.features.query(q)
+                subset = self.features.query(q).reset_index(drop=True)
 
             self.counter += 1
             if len(subset.index) > 1:

--- a/deimos/subset.py
+++ b/deimos/subset.py
@@ -561,13 +561,12 @@ class MultiSamplePartitions:
                                                  self.bounds[self.counter][1])
 
             if self.dask:
-                subset = self.features.query(q).compute().reset_index(drop=True)
+                subset = self.features.query(q).compute()
             else:
-                subset = self.features.query(q).reset_index(drop=True)
+                subset = self.features.query(q)
 
             self.counter += 1
             if len(subset.index) > 1:
-                subset['partition_idx'] = self.counter
                 return subset
             else:
                 return None
@@ -603,6 +602,11 @@ class MultiSamplePartitions:
         else:
             with mp.Pool(processes=processes) as p:
                 result = list(p.imap(partial(func, **kwargs), self))
+
+        # Add partition index
+        for i in range(len(result)):
+            if result[i] is not None:
+                result[i]['partition_idx'] = i
 
         # Combine partitions
         return pd.concat(result, ignore_index=True)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
+import os
 from setuptools import find_packages, setup
+import sys
 
-with open('deimos/__init__.py') as f:
-    exec([x for x in f.readlines() if '__version__' in x][0])
+sys.path.append(os.path.dirname(__file__))
+
+import deimos
+
 
 with open('README.md') as f:
     readme = f.read()
@@ -16,7 +20,7 @@ pkgs = find_packages(exclude=('examples', 'docs', 'tests'))
 
 setup(
     name='deimos',
-    version=__version__,
+    version=deimos.__version__,
     description='Data Extraction for Integrated Multidimensional Spectrometry',
     long_description=readme,
     author='Sean M. Colby',


### PR DESCRIPTION
This PR primarily concerns representative retrieval during TDA-based peak detection. Formerly, random uniform noise was added to each intensity value to "uniqueify", whereupon the birth times returned by ripser could be mapped back to array coordinates. However, ripser currently only uses floating point 32 precision, potentially incurring ambiguous mappings.

The updated implementation groups input integer intensities with the same value, then appends an integer index 1...N per group of size N.

Additionally:
- Add or improve export formats (MGF, MSP, CSV)
- Improve version access during setup