### PR TITLE
Fix bug for calculating weighted mean using persistent homology when final dimension is singular

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,9 +38,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: miniforge3
+          miniforge-variant: MiniForge3
           miniforge-version: latest
           use-mamba: true
           environment-file: environment.yml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Citing DEIMoS
 -------------
 If you would like to reference deimos in an academic paper, we ask you include the following.
 
-* DEIMoS, version 1.5.0 http://github.com/pnnl/deimos (accessed MMM YYYY)
+* DEIMoS, version 1.5.1 http://github.com/pnnl/deimos (accessed MMM YYYY)
 * Colby, S.M., Chang, C.H., Bade, J.L., Nunez, J.R., Blumer, M.R., Orton, D.J., Bloodsworth, K.J., Nakayasu, E.S., Smith, R.D, Ibrahim, Y.M. and Renslow, R.S., 2022. DEIMoS: an open-source tool for processing high-dimensional mass spectrometry data. *Analytical Chemistry*, 94(16), pp.6130-6138.
 
 Disclaimer

--- a/conda.recipe/recipe.yaml
+++ b/conda.recipe/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "1.5.0" # TODO: obtain this from package directly
+  version: "1.5.1" # TODO: obtain this from package directly
 
 package:
   name: deimos

--- a/deimos/__init__.py
+++ b/deimos/__init__.py
@@ -4,4 +4,4 @@ from deimos.io import get_accessions, load, save, build_factors, build_index
 from deimos.subset import (collapse, locate, locate_asym,
                            multi_sample_partition, partition, slice, threshold)
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/deimos/peakpick.py
+++ b/deimos/peakpick.py
@@ -171,7 +171,10 @@ def persistent_homology(
         vals = deimos.filters.sparse_weighted_mean_filter(
             index, features[dims].values, V, radius=radius, pindex=pidx
         )
-        for i, dim in enumerate(dims):
-            peaks[dim + "_weighted"] = vals[:, i]
+        if len(dims) == 1:
+            peaks[dims[0] + "_weighted"] = vals
+        else:
+            for i, dim in enumerate(dims):
+                peaks[dim + "_weighted"] = vals[:, i]
 
     return peaks


### PR DESCRIPTION
Fixes #33 to allow persistent homology weighted mean to function when final dimension is singular.

Also updates miniconda version in CI/CD.