### PR TITLE
Add fallback option for three data point calibration for TWIMS

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           which deimos
           deimos --help
-          pytest
+          python -m pytest
   
   Deploy:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/deimos/calibration.py
+++ b/deimos/calibration.py
@@ -420,68 +420,149 @@ class CCSCalibration:
 
             # Linear regression
             if self.power:
-                # Define the power function: y = a + b * x^c
-                def power_func(x, a, b, c):
-                    return a + b * np.power(x, c)
+                # Check number of calibration points
+                n_points = len(self.ta)
                 
-                # Better initial guess for parameters [a, b, c]
-                # Use a more robust approach for initial guesses
-                y_range = np.max(self.reduced_ccs) - np.min(self.reduced_ccs)
-                x_range = np.max(self.ta) - np.min(self.ta)
+                # Minimum 3 points required for power law calibration
+                if n_points < 3:
+                    raise ValueError(
+                        f"Power law calibration requires at least 3 calibration points, "
+                        f"but only {n_points} provided."
+                    )
                 
-                # Try multiple starting points for robustness
-                p0_options = [
-                    [0, y_range / np.power(np.max(self.ta), 0.5), 0.5],
-                    [np.min(self.reduced_ccs) * 0.1, y_range / np.max(self.ta), 0.6],
-                    [0, np.mean(self.reduced_ccs) / np.power(np.mean(self.ta), 0.5), 0.4],
-                ]
-                
-                # Try fitting with different initial guesses
-                best_fit = None
-                best_error = float('inf')
-                
-                for p0 in p0_options:
-                    try:
-                        popt, pcov = curve_fit(
-                            power_func, 
-                            self.ta, 
-                            self.reduced_ccs, 
-                            p0=p0,
-                            maxfev=2000  # Increase max function evaluations
-                        )
-                        
-                        # Calculate fit quality
-                        residuals = self.reduced_ccs - power_func(self.ta, *popt)
-                        rms_error = np.sqrt(np.mean(residuals**2))
-                        
-                        if rms_error < best_error:
-                            best_fit = (popt, pcov)
-                            best_error = rms_error
+                # Use 2-parameter power law (y = a * x^b) for 3 points
+                # Use 3-parameter power law (y = a + b * x^c) for 4+ points
+                if n_points < 4:
+                    # Fallback to 2-parameter power law: y = a * x^b
+                    warnings.warn(
+                        f"Only {n_points} calibration points available. "
+                        "Using 2-parameter power law (y = a * x^b) instead of 3-parameter model.",
+                        UserWarning
+                    )
+                    
+                    def power_func_2param(x, a, b):
+                        return a * np.power(x, b)
+                    
+                    # Initial guesses for [a, b]
+                    y_mean = np.mean(self.reduced_ccs)
+                    x_mean = np.mean(self.ta)
+                    
+                    p0_options = [
+                        [y_mean / np.power(x_mean, 0.5), 0.5],
+                        [y_mean / np.power(x_mean, 0.6), 0.6],
+                        [y_mean / x_mean, 0.4],
+                    ]
+                    
+                    # Try fitting with different initial guesses
+                    best_fit = None
+                    best_error = float('inf')
+                    
+                    for p0 in p0_options:
+                        try:
+                            popt, pcov = curve_fit(
+                                power_func_2param,
+                                self.ta,
+                                self.reduced_ccs,
+                                p0=p0,
+                                maxfev=2000
+                            )
                             
-                    except RuntimeError:
-                        continue
+                            # Calculate fit quality
+                            residuals = self.reduced_ccs - power_func_2param(self.ta, *popt)
+                            rms_error = np.sqrt(np.mean(residuals**2))
+                            
+                            if rms_error < best_error:
+                                best_fit = (popt, pcov)
+                                best_error = rms_error
+                                
+                        except RuntimeError:
+                            continue
+                    
+                    if best_fit is None:
+                        raise RuntimeError("2-parameter power law calibration failed with all initial guesses")
+                    
+                    popt, pcov = best_fit
+                    
+                    # Store parameters (a=0 for 2-parameter model)
+                    a_param, b_param = popt
+                    self.a = 0  # No additive offset in 2-parameter model
+                    self.tfix = a_param
+                    self.beta = b_param
+                    
+                    # Calculate R-squared manually
+                    residuals = self.reduced_ccs - power_func_2param(self.ta, *popt)
+                    ss_res = np.sum(residuals**2)
+                    ss_tot = np.sum((self.reduced_ccs - np.mean(self.reduced_ccs))**2)
+                    r_squared = 1 - (ss_res / ss_tot)
+                    
+                    # Store fit stats
+                    r = np.sqrt(r_squared) if r_squared > 0 else 0
+                    p = None
+                    se = np.sqrt(np.diag(pcov))
                 
-                if best_fit is None:
-                    raise RuntimeError("Power law calibration failed with all initial guesses")
-                
-                popt, pcov = best_fit
-                
-                # Store parameters
-                a, b, c = popt
-                self.a = a
-                self.tfix = b
-                self.beta = c
-                
-                # Calculate R-squared manually
-                residuals = self.reduced_ccs - power_func(self.ta, *popt)
-                ss_res = np.sum(residuals**2)
-                ss_tot = np.sum((self.reduced_ccs - np.mean(self.reduced_ccs))**2)
-                r_squared = 1 - (ss_res / ss_tot)
-                
-                # Store fit stats
-                r = np.sqrt(r_squared) if r_squared > 0 else 0
-                p = None
-                se = np.sqrt(np.diag(pcov))
+                else:
+                    # Use 3-parameter power law for 4+ points
+                    # Define the power function: y = a + b * x^c
+                    def power_func(x, a, b, c):
+                        return a + b * np.power(x, c)
+                    
+                    # Better initial guess for parameters [a, b, c]
+                    # Use a more robust approach for initial guesses
+                    y_range = np.max(self.reduced_ccs) - np.min(self.reduced_ccs)
+                    
+                    # Try multiple starting points for robustness
+                    p0_options = [
+                        [0, y_range / np.power(np.max(self.ta), 0.5), 0.5],
+                        [np.min(self.reduced_ccs) * 0.1, y_range / np.max(self.ta), 0.6],
+                        [0, np.mean(self.reduced_ccs) / np.power(np.mean(self.ta), 0.5), 0.4],
+                    ]
+                    
+                    # Try fitting with different initial guesses
+                    best_fit = None
+                    best_error = float('inf')
+                    
+                    for p0 in p0_options:
+                        try:
+                            popt, pcov = curve_fit(
+                                power_func, 
+                                self.ta, 
+                                self.reduced_ccs, 
+                                p0=p0,
+                                maxfev=2000  # Increase max function evaluations
+                            )
+                            
+                            # Calculate fit quality
+                            residuals = self.reduced_ccs - power_func(self.ta, *popt)
+                            rms_error = np.sqrt(np.mean(residuals**2))
+                            
+                            if rms_error < best_error:
+                                best_fit = (popt, pcov)
+                                best_error = rms_error
+                                
+                        except RuntimeError:
+                            continue
+                    
+                    if best_fit is None:
+                        raise RuntimeError("Power law calibration failed with all initial guesses")
+                    
+                    popt, pcov = best_fit
+                    
+                    # Store parameters
+                    a, b, c = popt
+                    self.a = a
+                    self.tfix = b
+                    self.beta = c
+                    
+                    # Calculate R-squared manually
+                    residuals = self.reduced_ccs - power_func(self.ta, *popt)
+                    ss_res = np.sum(residuals**2)
+                    ss_tot = np.sum((self.reduced_ccs - np.mean(self.reduced_ccs))**2)
+                    r_squared = 1 - (ss_res / ss_tot)
+                    
+                    # Store fit stats
+                    r = np.sqrt(r_squared) if r_squared > 0 else 0
+                    p = None
+                    se = np.sqrt(np.diag(pcov))
             else:
                 self.a = 0
                 beta, tfix, r, p, se = linregress(self.ta, self.reduced_ccs)

--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,7 @@ dependencies:
   - pandas
   - pip
   - pymzml
+  - pytest
   - pytables
   - python
   - scikit-learn

--- a/tests/test_calibration.py
+++ b/tests/test_calibration.py
@@ -50,6 +50,40 @@ def twims_data():
         "q": [1, 1, 1, 1, 1],
     }
 
+
+@pytest.fixture()
+def twims_data_3point():
+    """TWIMS-like data with only 3 points (for fallback testing)"""
+    return {
+        "mz": [298.3472, 354.4099, 410.4726],
+        "ta": [399.358, 466.0836, 533.259],
+        "ccs": [190.61, 213.84, 236.4],
+        "q": [1, 1, 1],
+    }
+
+
+@pytest.fixture()
+def twims_data_2point():
+    """TWIMS-like data with only 2 points (insufficient for power)"""
+    return {
+        "mz": [298.3472, 410.4726],
+        "ta": [399.358, 533.259],
+        "ccs": [190.61, 236.4],
+        "q": [1, 1],
+    }
+
+
+@pytest.fixture()
+def twims_data_1point():
+    """TWIMS-like data with only 1 point (insufficient for power)"""
+    return {
+        "mz": [298.3472],
+        "ta": [399.358],
+        "ccs": [190.61],
+        "q": [1],
+    }
+
+
 class TestMassCalibration:
     def test_init(self, ccs_cal):
         for attr, expected in zip(["beta", "tfix", "fit"], [None, None, dict]):
@@ -223,6 +257,49 @@ class TestCCSCalibration:
         error = np.abs(ta - twims_data["ta"]) / twims_data["ta"]
         assert (error <= 0.01).all()
 
+    def test_calibrate_power_3point_fallback(self, ccs_cal, twims_data_3point):
+        """Test 2-parameter power law fallback with only 3 calibration points"""
+        # Test that a warning is raised
+        with pytest.warns(UserWarning, match="Only 3 calibration points available"):
+            ccs_cal.calibrate(power=True, **twims_data_3point)
+        
+        # Verify power mode is enabled
+        assert ccs_cal.power is True
+        
+        # Verify 2-parameter model (a should be 0)
+        assert ccs_cal.a == 0
+        assert ccs_cal.beta is not None
+        assert ccs_cal.tfix is not None
+        
+        # Test forward conversion (arrival time -> CCS)
+        ccs = ccs_cal.arrival2ccs(
+            twims_data_3point["mz"], 
+            twims_data_3point["ta"], 
+            q=twims_data_3point["q"]
+        )
+        error = np.abs(ccs - twims_data_3point["ccs"]) / twims_data_3point["ccs"]
+        assert (error <= 0.05).all()
+        
+        # Verify reverse conversion works (may have lower accuracy)
+        ta = ccs_cal.ccs2arrival(
+            twims_data_3point["mz"], 
+            twims_data_3point["ccs"], 
+            q=twims_data_3point["q"]
+        )
+        # Just verify it returns values in reasonable range
+        assert np.all(ta > 0)
+        assert np.all(np.isfinite(ta))
+
+    def test_calibrate_power_insufficient_points_2(self, ccs_cal, twims_data_2point):
+        """Test that power calibration fails with only 2 points"""
+        with pytest.raises(ValueError, match="at least 3 calibration points"):
+            ccs_cal.calibrate(power=True, **twims_data_2point)
+
+    def test_calibrate_power_insufficient_points_1(self, ccs_cal, twims_data_1point):
+        """Test that power calibration fails with only 1 point"""
+        with pytest.raises(ValueError, match="at least 3 calibration points"):
+            ccs_cal.calibrate(power=True, **twims_data_1point)
+
 
 @pytest.mark.parametrize(
     "calc,beta,tfix,beta_exp,tfix_exp",
@@ -259,3 +336,55 @@ def test_calibrate_ccs_function_power(twims_data):
     ccs = ccs_cal.arrival2ccs(twims_data["mz"], twims_data["ta"], q=twims_data["q"])
     error = np.abs(ccs - twims_data["ccs"]) / twims_data["ccs"]
     assert (error <= 0.01).all()
+
+
+def test_calibrate_ccs_power_3point_fallback(twims_data_3point):
+    """Test 2-parameter power law fallback for TWIMS with only 3 calibration points"""
+    # Test that a warning is raised
+    with pytest.warns(UserWarning, match="Only 3 calibration points available"):
+        ccs_cal = deimos.calibration.calibrate_ccs(power=True, **twims_data_3point)
+    
+    # Verify power mode is enabled
+    assert ccs_cal.power is True
+    
+    # Verify 2-parameter model (a should be 0)
+    assert ccs_cal.a == 0
+    assert ccs_cal.beta is not None
+    assert ccs_cal.tfix is not None
+    
+    # Test forward conversion (arrival time -> CCS)
+    ccs = ccs_cal.arrival2ccs(
+        twims_data_3point["mz"], 
+        twims_data_3point["ta"], 
+        q=twims_data_3point["q"]
+    )
+    error = np.abs(ccs - twims_data_3point["ccs"]) / twims_data_3point["ccs"]
+    # Allow higher tolerance for 3-point fit with 2-parameter model
+    assert (error <= 0.05).all()
+    
+    # Verify fit statistics are available
+    assert ccs_cal.fit["r"] is not None
+    assert ccs_cal.fit["se"] is not None
+    
+    # Verify reverse conversion works (may have lower accuracy)
+    ta = ccs_cal.ccs2arrival(
+        twims_data_3point["mz"], 
+        twims_data_3point["ccs"], 
+        q=twims_data_3point["q"]
+    )
+    # Just verify it returns values in reasonable range
+    assert np.all(ta > 0)
+    assert np.all(np.isfinite(ta))
+
+
+def test_calibrate_ccs_power_insufficient_points_2(twims_data_2point):
+    """Test that power calibration fails with only 2 points"""
+    with pytest.raises(ValueError, match="at least 3 calibration points"):
+        deimos.calibration.calibrate_ccs(power=True, **twims_data_2point)
+
+
+def test_calibrate_ccs_power_insufficient_points_1(twims_data_1point):
+    """Test that power calibration fails with only 1 point"""
+    with pytest.raises(ValueError, match="at least 3 calibration points"):
+        deimos.calibration.calibrate_ccs(power=True, **twims_data_1point)
+


### PR DESCRIPTION
This PR enables a fallback option for TWIMS CCS calibration (deimos.calibration.calibrate_ccs with power = TRUE) for the scenario where we only have three calibration points. It does this by using the formula y = a*x^b, where y is reduced CCS, x is drift time, fit for a and b.  Added associated tests to cover scenarios with <4 calibration points for power law calibrations.

It also fixes a small CI/CD error regarding pytest.