### PR TITLE
Keep same-sample peaks in separate agglomerative clusters

### DIFF
--- a/deimos/alignment.py
+++ b/deimos/alignment.py
@@ -2,7 +2,6 @@ import numpy as np
 import scipy
 from scipy import sparse
 from scipy.spatial import KDTree
-from scipy.spatial.distance import cdist
 from sklearn.cluster import AgglomerativeClustering
 from sklearn.svm import SVR
 
@@ -299,13 +298,6 @@ def agglomerative_clustering(
     # Copy input
     features = features.copy()
 
-    # Connectivity
-    if "sample_idx" not in features.columns:
-        cmat = None
-    else:
-        vals = features["sample_idx"].values.reshape(-1, 1)
-        cmat = cdist(vals, vals, metric=lambda x, y: x != y).astype(bool)
-
     # Compute inter-feature distances
     distances = []
     for i, d in enumerate(dims):
@@ -333,6 +325,12 @@ def agglomerative_clustering(
     # Max distance
     distances = np.max(distances, axis=-1)
 
+    if "sample_idx" in features.columns:
+        sample_idx = np.asarray(features["sample_idx"])
+        same_sample = sample_idx[:, None] == sample_idx[None, :]
+        np.fill_diagonal(same_sample, False)
+        distances[same_sample] = 2.0
+
     # Perform clustering
     try:
         clustering = AgglomerativeClustering(
@@ -340,7 +338,6 @@ def agglomerative_clustering(
             linkage="complete",
             metric="precomputed",
             distance_threshold=1,
-            connectivity=cmat,
         ).fit(distances)
         features["cluster"] = clustering.labels_
 

--- a/deimos/alignment.py
+++ b/deimos/alignment.py
@@ -265,10 +265,16 @@ def agglomerative_clustering(
     the pair of clusters that minimally increases a given linkage distance.
     See :class:`sklearn.cluster.AgglomerativeClustering`.
 
+    When ``sample_idx`` is present, same-sample pairs are treated as
+    unlinkable: their precomputed distance is set above
+    ``distance_threshold`` so complete linkage cannot merge two features
+    from the same sample, including through parent clusters.
+
     Parameters
     ----------
     features : :obj:`~pandas.DataFrame` or :obj:`~dask.dataframe.DataFrame`
-        Input feature coordinates and intensities per sample.
+        Input feature coordinates and intensities per sample. An optional
+        ``sample_idx`` column identifies the source sample.
     dims : str or list
         Dimensions considered in clustering.
     tol : float or list

--- a/docs/source/user_guide/alignment.ipynb
+++ b/docs/source/user_guide/alignment.ipynb
@@ -334,9 +334,7 @@
    "source": [
     "Agglomerative clustering is implemented via scikit-learn using a custom distance matrix to ensure the maximum linkage distance does not exceed the user-specified tolerance in any one dimension, i.e. Chebyshev distance or L-infinity norm.\n",
     "Cluster affinity is defined by complete linkage, which uses the maximum of the distances between all observations of two sets to qualify a merge.\n",
-    "To ensure that features are merged into clusters across datasets, not within, a connectivity matrix is automatically generated to mask intrasample linkages.\n",
-    "However, intra-dataset clustering can occur when parent nodes unconstrained by the connectivity matrix are merged, resulting in the clustering of distal, nonadjacent child nodes.\n",
-    "We note that nodes are not merged if the maximum linkage distance is exceeded. Thus, to prevent erroneous feature merges, the user can simply reduce their selected tolerances."
+    "When a `sample_idx` column is present, same-sample pairs are given a precomputed distance above the merge threshold so features are clustered across samples, not within a sample.\n"
    ]
   }
  ],

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -206,3 +206,97 @@ def test_agglomerative_clustering_same_sample_idx_not_merged():
     assert result is not None
     assert "cluster" in result.columns
     assert result["cluster"].nunique() == 2
+
+
+def test_agglomerative_clustering_different_sample_idx_merged():
+    features = pd.DataFrame(
+        {
+            "mz": [200.0, 200.0],
+            "ccs": [150.0, 150.1],
+            "intensity": [10.0, 20.0],
+            "sample_idx": [0, 1],
+        }
+    )
+
+    result = deimos.alignment.agglomerative_clustering(
+        features,
+        dims=["mz", "ccs"],
+        tol=[20e-6, 2.0],
+        relative=[True, False],
+    )
+
+    assert result["cluster"].nunique() == 1
+
+
+def test_agglomerative_clustering_different_sample_idx_out_of_tol_not_merged():
+    features = pd.DataFrame(
+        {
+            "mz": [200.0, 200.0],
+            "ccs": [150.0, 160.0],
+            "intensity": [10.0, 20.0],
+            "sample_idx": [0, 1],
+        }
+    )
+
+    result = deimos.alignment.agglomerative_clustering(
+        features,
+        dims=["mz", "ccs"],
+        tol=[20e-6, 2.0],
+        relative=[True, False],
+    )
+
+    assert result["cluster"].nunique() == 2
+
+
+def test_agglomerative_clustering_pairs_across_samples_not_within():
+    features = pd.DataFrame(
+        {
+            "mz": [200.0, 200.0, 200.0, 200.0],
+            "ccs": [150.0, 150.1, 150.0, 150.1],
+            "intensity": [10.0, 20.0, 11.0, 21.0],
+            "sample_idx": [0, 0, 1, 1],
+        }
+    )
+
+    result = deimos.alignment.agglomerative_clustering(
+        features,
+        dims=["mz", "ccs"],
+        tol=[20e-6, 2.0],
+        relative=[True, False],
+    )
+
+    assert result["cluster"].nunique() == 2
+    for _, group in result.groupby("cluster"):
+        assert group["sample_idx"].nunique() == len(group)
+        assert group["ccs"].nunique() == 1
+
+
+def test_agglomerative_clustering_without_sample_idx_still_merges():
+    features = pd.DataFrame(
+        {
+            "mz": [200.0, 200.0],
+            "ccs": [150.0, 150.1],
+            "intensity": [10.0, 20.0],
+        }
+    )
+
+    result = deimos.alignment.agglomerative_clustering(
+        features,
+        dims=["mz", "ccs"],
+        tol=[20e-6, 2.0],
+        relative=[True, False],
+    )
+
+    assert result["cluster"].nunique() == 1
+
+
+def test_agglomerative_clustering_none():
+    assert (
+        deimos.alignment.agglomerative_clustering(
+            None,
+            dims=["mz"],
+            tol=[20e-6],
+            relative=[True],
+        )
+        is None
+    )

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -186,6 +186,23 @@ def test_fit_spline():
         raise NotImplementedError
 
 
-def test_agglomerative_clustering():
-    with pytest.raises(NotImplementedError):
-        raise NotImplementedError
+def test_agglomerative_clustering_same_sample_idx_not_merged():
+    features = pd.DataFrame(
+        {
+            "mz": [200.0, 200.0],
+            "ccs": [150.0, 150.1],
+            "intensity": [10.0, 20.0],
+            "sample_idx": [0, 0],
+        }
+    )
+
+    result = deimos.alignment.agglomerative_clustering(
+        features,
+        dims=["mz", "ccs"],
+        tol=[20e-6, 2.0],
+        relative=[True, False],
+    )
+
+    assert result is not None
+    assert "cluster" in result.columns
+    assert result["cluster"].nunique() == 2


### PR DESCRIPTION
Fixes #55

`sample_idx` no longer goes through sklearn `connectivity`, which completes disconnected graphs and merges same-sample peaks. Same-sample pairs now get a precomputed distance of 2 (above the merge threshold) so complete linkage cannot put two features from one sample in the same cluster, including through parent nodes. This also removes the scipy 1.18 `cdist` lambda crash on the `sample_idx` path.

Tests cover same-sample split, cross-sample merge, parent-node pairing, and the no-`sample_idx` path.